### PR TITLE
Align Stripe checkout metadata keys

### DIFF
--- a/app/actions/stripe.ts
+++ b/app/actions/stripe.ts
@@ -199,8 +199,8 @@ export async function createCheckoutSession(planId: string) {
       successUrl: `${origin}/subscription/success?session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${origin}/subscription`,
       metadata: {
-        plan_id: planId,
-        user_id: user.id,
+        planId,
+        userId: user.id,
       },
       trialDays: plan.trial_days || undefined,
     })


### PR DESCRIPTION
## Summary
- align the checkout session metadata keys with the webhook expectations

## Testing
- not run (requires manual Stripe checkout which is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e627dfe3d8832e88cf42c58b9e88ab